### PR TITLE
Include channelId in cookie name

### DIFF
--- a/src/containers/App/index.js
+++ b/src/containers/App/index.js
@@ -31,7 +31,7 @@ class App extends Component {
 
   componentDidMount () {
     const { channelId, token, preferences, noCredentials, onRef } = this.props
-    const credentials = getCredentialsFromCookie()
+    const credentials = getCredentialsFromCookie(channelId)
     const payload = { channelId, token }
 
     if (onRef) {
@@ -46,7 +46,7 @@ class App extends Component {
       Object.assign(payload, credentials)
     } else {
       this.props.createConversation(channelId, token).then(({ id, chatId }) => {
-        storeCredentialsInCookie(chatId, id, preferences.conversationTimeToLive)
+        storeCredentialsInCookie(chatId, id, preferences.conversationTimeToLive, channelId)
       })
     }
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -8,13 +8,19 @@ export const truncate = (string, length) => {
   return `${string.slice(0, length - 3)}...`
 }
 
-export const storeCredentialsInCookie = (chatId, conversationId, timeToLive) => {
-  const payload = { chatId, conversationId }
-  Cookies.set('cai-conversation', JSON.stringify(payload), { expires: 3600 * timeToLive })
+export const getCredentialCookieName = (channelId) => {
+  return `cai-conversation-${channelId}`
 }
 
-export const getCredentialsFromCookie = () => {
-  let credentials = Cookies.get('cai-conversation')
+export const storeCredentialsInCookie = (chatId, conversationId, timeToLive, channelId) => {
+  const payload = { chatId, conversationId }
+  const cookieName = getCredentialCookieName(channelId)
+  Cookies.set(cookieName, JSON.stringify(payload), { expires: 3600 * timeToLive })
+}
+
+export const getCredentialsFromCookie = (channelId) => {
+  const cookieName = getCredentialCookieName(channelId)
+  let credentials = Cookies.get(cookieName)
 
   if (credentials) {
     try {


### PR DESCRIPTION
When the cookie name includes the channelId, more than one webchat can be used per domain.
Without this commit, multiple webchats per domain is leading to not responding chatbots without a proper user feedback.
This issue is described here as well: https://github.com/SAPConversationalAI/Webchat/issues/33


